### PR TITLE
remove unnecessary 'self.' in Subdomain?

### DIFF
--- a/blogs/lib/subdomain.rb
+++ b/blogs/lib/subdomain.rb
@@ -1,5 +1,5 @@
 class Subdomain
-  def self.matches?(request)
+  def matches?(request)
     request.subdomain.present? && request.subdomain != "www"
   end
 end


### PR DESCRIPTION
Not sure if this is a typo or if things have changed in Rails 4, but I was trying to do something similar and had to remove 'self.' from the method name in order to get this to work in my Rails 4 app. There's an example in the docs similar, here: http://guides.rubyonrails.org/routing.html#advanced-constraints
